### PR TITLE
Fix Hugo language configuration error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ Gemfile.lock
 .hugo_build.lock
 .DS_Store
 public/
+resources/
+my-hugo-site/public/
+my-hugo-site/resources/

--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -5,7 +5,7 @@
 theme = "blowfish"
 baseURL = "https://rex-manor.github.io/"
 publishDir = "docs"
-defaultContentLanguage = "en-us"
+defaultContentLanguage = "en"
 
 pluralizeListTitles = "true" # hugo function useful for non-english languages, find out more in  https://gohugo.io/getting-started/configuration/#pluralizelisttitles
 


### PR DESCRIPTION
I changed defaultContentLanguage from 'en-us' to 'en' in hugo.toml to match the defined language code in languages.en.toml.

This resolves the error: 'failed to decode "languages": config value "en-us" for defaultContentLanguage does not match any language definition'.

I also ensured 'resources/' is added to .gitignore.