### PR TITLE
feat: Add Google Analytics tracking

### DIFF
--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -17,7 +17,7 @@ buildFuture = false
 
 enableEmoji = true
 
-# googleAnalytics = "G-XXXXXXXXX"
+googleAnalytics = "G-GD83H0HBV6"
 
 [pagination]
   pagerSize = 100


### PR DESCRIPTION
## Summary
- Enable Google Analytics with tracking ID G-GD83H0HBV6 to monitor site traffic

## Test plan
- [ ] Verify staging deployment includes GA script in page source
- [ ] Confirm analytics events appear in Google Analytics dashboard after visiting the site

🤖 Generated with [Claude Code](https://claude.com/claude-code)