### PR TITLE
Add February 2026 'Looking Ahead' blog post

### DIFF
--- a/content/news/2026-02-looking-ahead.md
+++ b/content/news/2026-02-looking-ahead.md
@@ -1,0 +1,37 @@
+---
+title: "Looking Ahead: Tech History, Spring Forward, and Block Party Planning"
+date: 2026-02-07
+summary: "As spring approaches, get ready for a major tech anniversary at CHM, the start of Daylight Saving Time, and the kickoff for our annual Block Party planning."
+---
+
+Happy almost-Spring, neighbors!
+
+It’s hard to believe we’re already looking towards March, but with the days getting longer, there is plenty to look forward to in and around Rex Manor. Here are a few key dates and updates to keep on your radar.
+
+### Computer History Museum: Apple at 50
+
+We are incredibly lucky to live so close to the [Computer History Museum](https://computerhistory.org/), which consistently brings world-class events to our doorstep.
+
+On **Wednesday, March 11, 2026 at 7:00 PM**, CHM will be hosting a special event: **"Apple at 50"**. This promises to be a fascinating look back at half a century of innovation that has shaped not just Silicon Valley, but the entire world. It’s a wonderful opportunity to celebrate the creativity and technological advancements that are part of our local DNA. Tickets are likely to go fast, so I recommend checking the [museum website](https://computerhistory.org/) soon if you’re interested.
+
+### Spring Forward: Daylight Saving Time
+
+Don't forget to mark your calendars (or set your smart home devices)! **Daylight Saving Time begins on Sunday, March 8, 2026**.
+
+While losing an hour of sleep is never fun, the trade-off is more evening sunlight to enjoy walks around the neighborhood or visits to **Rex Manor Park**. It’s a sure sign that spring—and warmer weather—is on its way.
+
+### Block Party Planning Kickoff
+
+Speaking of warmer weather, it’s time to start thinking about our favorite neighborhood tradition: the **Rex Manor Annual Block Party**!
+
+Typically held in June, this event is a highlight of the year and a fantastic way to connect with long-time friends and welcome new neighbors to the community. To make it happen, we need a team of enthusiastic volunteers. Whether you’re a party-planning pro or just want to help set up tables, your involvement is what makes this event special.
+
+We are starting the planning discussions now on our neighborhood Google Group. If you have ideas for food, games, or entertainment—or if you just want to lend a hand—please jump in!
+
+### Join the Conversation
+
+As always, the best way to stay in the loop and participate in these discussions is via our **[rex-manor-neighbors Google Group](https://groups.google.com/g/rex-manor-neighbors)**. It’s where we coordinate everything from the Block Party to neighborhood watch updates.
+
+Here’s to a bright and innovative spring ahead!
+
+— David Watson

--- a/content/news/2026-02-looking-ahead.md
+++ b/content/news/2026-02-looking-ahead.md
@@ -16,7 +16,9 @@ On **Wednesday, March 11, 2026 at 7:00 PM**, CHM will be hosting a special event
 
 ### Spring Forward: Daylight Saving Time
 
-Don't forget to mark your calendars (or set your smart home devices)! **Daylight Saving Time begins on Sunday, March 8, 2026**.
+**Daylight Saving Time begins on Sunday, March 8, 2026**.
+
+I rely so much on my phone and watch to update themselves that I sometimes don't even notice the time change—until I'm confused why it's still so dark outside despite getting out of bed at my usual time!
 
 While losing an hour of sleep is never fun, the trade-off is more evening sunlight to enjoy walks around the neighborhood or visits to **Rex Manor Park**. It’s a sure sign that spring—and warmer weather—is on its way.
 


### PR DESCRIPTION
Added a new blog post 'Looking Ahead: Tech History, Spring Forward, and Block Party Planning'. Covers the upcoming 'Apple at 50' event at CHM, Daylight Saving Time start, and the kickoff for the annual Block Party planning. Verified content and build.

---
*PR created automatically by Jules for task [5060988747419759808](https://jules.google.com/task/5060988747419759808) started by @davidfwatson*