### PR TITLE
Add blog post for March 2026 events

### DIFF
--- a/content/news/2026-02-march-preview.md
+++ b/content/news/2026-02-march-preview.md
@@ -1,0 +1,37 @@
+---
+title: "March Preview: Science, Sustainability, and Local Talent"
+date: 2026-02-14
+summary: "Upcoming events for March 2026 including a science talk at MVCPA, a Repair Café at Hacker Dojo, and local youth theater."
+---
+
+Happy Valentine's Day, neighbors!
+
+As we enjoy the last few weeks of winter, the calendar for March is already filling up with some fantastic local events. Whether you are interested in cutting-edge science, sustainability, or supporting our local youth, there is something for everyone just a short trip from Rex Manor.
+
+### The Amazing Nature of Animal Senses
+
+First up, the **Mountain View Center for the Performing Arts (MVCPA)** is hosting a truly fascinating event. On **Tuesday, March 3, 2026, at 7:00 PM**, Pulitzer Prize-winning science writer **Ed Yong** will be presenting **"The Amazing Nature of Animal Senses."**
+
+Based on his bestselling book *An Immense World*, this talk promises to take us beyond the limits of human perception to explore how other creatures experience the world. It is a wonderful example of how science can expand our understanding and appreciation of nature. This event is presented by the Peninsula Open Space Trust (POST), and tickets are available through the [MVCPA website](https://www.mvcpa.com/events).
+
+### Repair Café at Hacker Dojo
+
+For those of us who love to tinker—or just hate throwing things away—**Hacker Dojo** (855 Maude Ave) is hosting a **Repair Café** on **Sunday, March 29, 2026, from 11:00 AM to 3:00 PM**.
+
+This is a brilliant community initiative where volunteers help you fix broken household items, electronics, bikes, and more—for free! It is technology at its best: practical, sustainable, and community-driven. Instead of discarding that toaster or lamp, bring it down to the Dojo and give it a second life. You can learn more at the [Repair Café Silicon Valley website](https://repaircafesv.org/).
+
+While you are there, check out the Dojo itself—it is a cornerstone of our local tech scene and a great place to meet fellow makers and innovators.
+
+### Peninsula Youth Theatre: Newsies
+
+Support our local young talent! The **Peninsula Youth Theatre (PYT)** will be performing Disney's **"Newsies"** at the MVCPA from **March 14 through March 22**.
+
+It is always inspiring to see the dedication and skill of our community's youth. These shows are high-energy, fun for the whole family, and a great way to spend an afternoon or evening downtown. Tickets and showtimes are available at [pyt.org](https://pyt.org/).
+
+### Join the Discussion
+
+As always, if you hear of other great events or want to organize a meetup before heading to one of these, jump onto the **[rex-manor-neighbors Google Group](https://groups.google.com/g/rex-manor-neighbors)**. It is the best place to share news, ask questions, and stay connected with your neighbors.
+
+Here is to a curious and connected March!
+
+— David Watson


### PR DESCRIPTION
Added a new blog post `content/news/2026-02-march-preview.md` covering upcoming events in Mountain View for March 2026. The post is written from the perspective of David Watson and includes links to the events and the neighborhood Google Group.

---
*PR created automatically by Jules for task [5445329592371236516](https://jules.google.com/task/5445329592371236516) started by @davidfwatson*