### PR TITLE
Add March 2026 events blog post

### DIFF
--- a/content/news/2026-02-spring-events.md
+++ b/content/news/2026-02-spring-events.md
@@ -1,0 +1,35 @@
+---
+title: "March in Rex Manor: Science, Stage, and Sustainability"
+date: 2026-02-22
+summary: "A look at exciting March events including Broadway at MVCPA, repair workshops at Hacker Dojo, and family fun at the Computer History Museum."
+---
+
+Hello neighbors!
+
+With March just around the corner, our local calendar is filling up with events that showcase the best of Mountain View—from world-class science talks and theater to community-driven sustainability efforts. Whether you're looking to learn something new, fix something old, or just enjoy a night out, there’s plenty happening right here in our backyard.
+
+### MVCPA: Science & Stage
+
+The **Mountain View Center for the Performing Arts (MVCPA)** continues to bring incredible talent to our city.
+
+*   **The Amazing Nature of Animal Senses:** On **Tuesday, March 3**, Pulitzer Prize-winning science writer **Ed Yong** will be discussing his book *An Immense World*. Hosted by the Peninsula Open Space Trust (POST), this event delves into the fascinating sensory worlds of animals. While tickets are in high demand (and may be waitlist-only), it’s worth checking the [MVCPA website](https://tickets.mvcpa.com/) or the [POST event page](https://openspacetrust.org/event/ed-yong/) for availability or virtual viewing options. It’s a wonderful opportunity to see science communication at its best.
+*   **Newsies The Musical:** Later in the month, get ready to "Seize the Day" with **Peninsula Youth Theatre's** production of Disney's *Newsies*. Running from **March 14 to March 22**, this high-energy show is perfect for families and theater lovers alike. Supporting our local youth arts programs is always a joy, and you can grab your tickets [here](https://tickets.mvcpa.com/).
+
+### Tech & Community: Fix It & Celebrate
+
+Our neighborhood’s connection to the tech world isn't just about startups and software; it's also about community and innovation.
+
+*   **Repair Café at Hacker Dojo:** On **Sunday, March 29, from 11:00 AM to 3:00 PM**, head over to the **Hacker Dojo** (855 Maude Avenue) for a **Repair Café**. If you have a broken toaster, a wobbly chair, or a torn shirt, don’t throw it away! Volunteers will be on hand to help you fix your beloved items for free. It’s a fantastic way to reduce waste, learn new skills, and meet neighbors who love to tinker. More details can be found at [Repair Café Silicon Valley](https://repaircafesv.org/).
+*   **TechFest: Happy Birthday, Apple:** Following the "Apple at 50" talk earlier in the month, the **Computer History Museum** is hosting a family-friendly **TechFest** on **Saturday, March 28**. Expect hands-on activities, vintage computers, and a celebration of 50 years of computing history. It’s a great way to introduce the kids to the technology that shaped our region. Check out the [museum’s event page](https://computerhistory.org/events/techfest-9/) for more info.
+
+### Nature: Deer Hollow Farm Spring Tours
+
+Finally, for those wanting to enjoy the spring weather, **Deer Hollow Farm** is offering **Spring Tours** on **Saturday, March 28**. This is a lovely chance to see the farm animals and enjoy the open space preserve. You can find more details on the [City of Mountain View website](https://www.mountainview.gov/our-city/departments/community-services/special-events).
+
+### Join the Conversation
+
+As we head into this busy season, don't forget to keep an eye on the **[rex-manor-neighbors Google Group](https://groups.google.com/g/rex-manor-neighbors)**. It’s the best place to discuss these events, coordinate carpools, or just chat about what’s happening in the neighborhood.
+
+See you around town!
+
+— David Watson


### PR DESCRIPTION
This commit adds a new blog post titled "March in Rex Manor: Science, Stage, and Sustainability" to content/news/2026-02-spring-events.md. The post highlights upcoming local events in Mountain View for March 2026, including Ed Yong at MVCPA, Newsies at MVCPA, Repair Café at Hacker Dojo, TechFest at CHM, and Deer Hollow Farm tours. The tone is positive, pro-tech, and neighborly, signed by David Watson.

---
*PR created automatically by Jules for task [6354226013020440638](https://jules.google.com/task/6354226013020440638) started by @davidfwatson*