### PR TITLE
Add March 2026 events blog post

### DIFF
--- a/content/news/2026-03-march-events.md
+++ b/content/news/2026-03-march-events.md
@@ -1,0 +1,37 @@
+---
+title: "March 2026 Events: Tech Anniversaries, Local Arts, and Community Gatherings"
+date: 2026-02-28
+summary: "Get ready for an action-packed March featuring Apple's 50th at CHM, amazing shows at MVCPA, a Repair Café at Hacker Dojo, and a save-the-date for our block party!"
+---
+
+Happy almost-March, neighbors!
+
+Spring is just around the corner, and our vibrant Mountain View community has an incredible lineup of events to celebrate. From world-class technology history to fantastic local arts and community gatherings, there is something for everyone this month. It's a great time to appreciate the wonderful amenities and dynamic growth that make our city such a wonderful place to live.
+
+### Computer History Museum: Celebrating Apple's 50th
+
+Our neighborhood's proximity to the [Computer History Museum](https://computerhistory.org/) continues to provide us with amazing opportunities. This month is especially significant as they celebrate a major milestone in tech history.
+
+*   **Apple at 50:** On **Wednesday, March 11, 2026 at 7:00 PM**, CHM is hosting a special "Apple at 50" event. This is an incredible opportunity to look back at the innovations that have profoundly shaped our local tech landscape and the broader world.
+*   **TechFest: Happy Birthday, Apple:** The celebration continues on **Saturday, March 28, 2026 from 10:00 AM to 4:00 PM** with an all-day TechFest. Bring the family to get hands-on with vintage Apple computers from the Retro Roadshow, and enjoy a day dedicated to half a century of technological innovation!
+
+It's a wonderful reminder of the positive impact the tech industry has on our community, fostering both economic vitality and a culture of forward-thinking invention.
+
+### Arts and Culture at MVCPA
+
+The [Mountain View Center for the Performing Arts](https://www.mvcpa.com/) also has some excellent offerings this month:
+
+*   **The Amazing Nature of Animal Senses:** On **Tuesday, March 3, 2026 at 7:00 PM**, science journalist Ed Yong will be giving a fascinating talk presented by the Peninsula Open Space Trust (POST).
+*   **Newsies:** If you are looking for a great musical, the Peninsula Youth Theatre is putting on *Newsies* from **March 14 to March 22, 2026**. It's always great to support our local performing arts scene.
+
+### Hacker Dojo: Repair Café
+
+Over at the [Hacker Dojo](https://hackerdojo.com/) (855 Maude Ave), there is a **Repair Café** happening on **Sunday, March 29, 2026**. This is a great community-driven event where you can bring your broken items and learn how to fix them with the help of knowledgeable volunteers. It's a smart blend of hands-on technical skills, sustainability, and community spirit.
+
+### Save the Date: Rex Manor Block Party
+
+Finally, as recently discussed on our [rex-manor-neighbors](https://groups.google.com/g/rex-manor-neighbors) Google Group, please mark your calendars! Our neighborhood block party is officially scheduled for **Sunday, June 7, 2026**. The block party has always been a highlight for our community. We are looking for volunteers to help organize and make this event a success, so please join the conversation on the Google Group if you'd like to lend a hand.
+
+I look forward to seeing many of you around town this month!
+
+— David Watson

--- a/content/news/2026-03-march-events.md
+++ b/content/news/2026-03-march-events.md
@@ -1,19 +1,18 @@
 ---
 title: "March 2026 Events: Tech Anniversaries, Local Arts, and Community Gatherings"
 date: 2026-02-28
-summary: "Get ready for an action-packed March featuring Apple's 50th at CHM, amazing shows at MVCPA, a Repair Café at Hacker Dojo, and a save-the-date for our block party!"
+summary: "Get ready for an action-packed March featuring TechFest at CHM, amazing shows at MVCPA, a Repair Café at Hacker Dojo, and a confirmed date for our block party!"
 ---
 
 Happy almost-March, neighbors!
 
 Spring is just around the corner, and our vibrant Mountain View community has an incredible lineup of events to celebrate. From world-class technology history to fantastic local arts and community gatherings, there is something for everyone this month. It's a great time to appreciate the wonderful amenities and dynamic growth that make our city such a wonderful place to live.
 
-### Computer History Museum: Celebrating Apple's 50th
+### Computer History Museum: TechFest & Apple's 50th
 
-Our neighborhood's proximity to the [Computer History Museum](https://computerhistory.org/) continues to provide us with amazing opportunities. This month is especially significant as they celebrate a major milestone in tech history.
+As mentioned in our last post, the [Computer History Museum](https://computerhistory.org/) is celebrating Apple's 50th anniversary on March 11. But the celebration doesn't stop there!
 
-*   **Apple at 50:** On **Wednesday, March 11, 2026 at 7:00 PM**, CHM is hosting a special "Apple at 50" event. This is an incredible opportunity to look back at the innovations that have profoundly shaped our local tech landscape and the broader world.
-*   **TechFest: Happy Birthday, Apple:** The celebration continues on **Saturday, March 28, 2026 from 10:00 AM to 4:00 PM** with an all-day TechFest. Bring the family to get hands-on with vintage Apple computers from the Retro Roadshow, and enjoy a day dedicated to half a century of technological innovation!
+*   **TechFest: Happy Birthday, Apple:** The celebration culminates on **Saturday, March 28, 2026 from 10:00 AM to 4:00 PM** with an all-day TechFest. Bring the family to get hands-on with vintage Apple computers from the Retro Roadshow, and enjoy a day dedicated to half a century of technological innovation!
 
 It's a wonderful reminder of the positive impact the tech industry has on our community, fostering both economic vitality and a culture of forward-thinking invention.
 
@@ -28,9 +27,11 @@ The [Mountain View Center for the Performing Arts](https://www.mvcpa.com/) also 
 
 Over at the [Hacker Dojo](https://hackerdojo.com/) (855 Maude Ave), there is a **Repair Café** happening on **Sunday, March 29, 2026**. This is a great community-driven event where you can bring your broken items and learn how to fix them with the help of knowledgeable volunteers. It's a smart blend of hands-on technical skills, sustainability, and community spirit.
 
-### Save the Date: Rex Manor Block Party
+### Block Party: Mark Your Calendars!
 
-Finally, as recently discussed on our [rex-manor-neighbors](https://groups.google.com/g/rex-manor-neighbors) Google Group, please mark your calendars! Our neighborhood block party is officially scheduled for **Sunday, June 7, 2026**. The block party has always been a highlight for our community. We are looking for volunteers to help organize and make this event a success, so please join the conversation on the Google Group if you'd like to lend a hand.
+Finally, as a follow-up to our planning kickoff, the date has been set! As recently discussed on our [rex-manor-neighbors](https://groups.google.com/g/rex-manor-neighbors) Google Group, our "Last & Final Neighborhood Block Party" is officially scheduled for **Sunday, June 7, 2026**.
+
+We are still looking for volunteers to help organize and make this event a success, so please continue to join the conversation on the Google Group if you'd like to lend a hand with things like the grant application or general setup.
 
 I look forward to seeing many of you around town this month!
 


### PR DESCRIPTION
Added a new blog post for March 2026 covering local events such as the Apple at 50 anniversary and TechFest at the Computer History Museum, performances at the MVCPA, a Repair Cafe at Hacker Dojo, and a save the date for the Rex Manor block party based on discussions from the Google Group. The post was written from a positive, pro-tech, and neighborly perspective, as requested.

---
*PR created automatically by Jules for task [8814078774825331871](https://jules.google.com/task/8814078774825331871) started by @davidfwatson*