### PR TITLE
Add March 2026 events and updates blog post

### DIFF
--- a/content/news/2026-03-events-and-updates.md
+++ b/content/news/2026-03-events-and-updates.md
@@ -1,7 +1,7 @@
 ---
-title: "March in Mountain View: TechFest, Arts, and Our Final Block Party"
+title: "March in Mountain View: TechFest, Arts, and Block Party Planning"
 date: 2026-03-07
-summary: "March is packed with exciting local events, from TechFest at the CHM to the Newsies musical at MVCPA, plus an important update on our neighborhood block party."
+summary: "March is packed with exciting local events, from TechFest at the CHM to the Newsies musical at MVCPA, plus an important update on our neighborhood block party planning."
 ---
 
 Hello neighbors,
@@ -26,11 +26,11 @@ If you are looking for some fantastic local entertainment, the musical **"Newsie
 
 For those wanting to enjoy the outdoors, **Deer Hollow Farm** tours are available in March 2026. Nestled in our beautiful local open spaces, these tours offer a great way to learn about local agriculture and nature. You can find more information about exploring our parks and open spaces on the [City of Mountain View website](https://mountainview.gov/).
 
-### Neighborhood Update: The Final Block Party
+### Neighborhood Update: Block Party Planning
 
-Lastly, as many of you have seen discussed on the [rex-manor-neighbors Google Group](https://groups.google.com/g/rex-manor-neighbors), we have an official date for our annual neighborhood gathering. Please mark your calendars: our **Final Neighborhood Block Party** will be held on **Sunday, June 7, 2026**.
+Lastly, as many of you have seen discussed on the [rex-manor-neighbors Google Group](https://groups.google.com/g/rex-manor-neighbors), we have an official date for our annual neighborhood gathering! Please mark your calendars: our **Neighborhood Block Party** will be held on **Sunday, June 7, 2026**.
 
-While it is bittersweet that this will be the last of these specific block parties, we are looking forward to making it the best one yet. Please continue to check the Google Group for updates on planning and volunteer opportunities.
+Block party planning has officially begun, and we are looking forward to making this a fantastic event for everyone. Please continue to check the Google Group for updates on planning and volunteer opportunities.
 
 Have a fantastic March!
 

--- a/content/news/2026-03-events-and-updates.md
+++ b/content/news/2026-03-events-and-updates.md
@@ -1,0 +1,37 @@
+---
+title: "March in Mountain View: TechFest, Arts, and Our Final Block Party"
+date: 2026-03-07
+summary: "March is packed with exciting local events, from TechFest at the CHM to the Newsies musical at MVCPA, plus an important update on our neighborhood block party."
+---
+
+Hello neighbors,
+
+March is here, bringing with it a fantastic lineup of community events that showcase the best of Mountain View's vibrant culture, our celebrated tech industry, and the natural beauty around us. It is a great time to be a Rex Manor resident, watching our city grow and offer so many diverse experiences.
+
+Here are a few local events and important updates to keep on your radar this month:
+
+### TechFest at the Computer History Museum
+
+As always, we are incredibly fortunate to have the [Computer History Museum](https://computerhistory.org/) right in our backyard. This month, they are hosting **TechFest** (March 2026), a celebration of the innovation and technological advancements that shape our local community and the world. It is a wonderful reminder of the positive impact the tech industry brings to our region, making Mountain View such a dynamic and forward-thinking place to live.
+
+### Repair Café at the Hacker Dojo
+
+On **March 29, 2026**, the [Hacker Dojo](https://hackerdojo.com/) (located at 855 Maude Avenue) will be hosting a **Repair Café**. This is a brilliant initiative where you can bring broken items and work with knowledgeable volunteers to fix them. It perfectly embodies the resourceful, community-minded spirit of our local tech scene. Whether you have a malfunctioning appliance or just want to learn more about how things work, it is a great event to check out.
+
+### Newsies at the MVCPA
+
+If you are looking for some fantastic local entertainment, the musical **"Newsies"** is running from **March 14 to March 22, 2026**, at the [Mountain View Center for the Performing Arts (MVCPA)](https://mvcpa.com/). Supporting our local arts scene is a wonderful way to connect with the broader Mountain View community and enjoy some top-tier performances without leaving the city.
+
+### Deer Hollow Farm Tours
+
+For those wanting to enjoy the outdoors, **Deer Hollow Farm** tours are available in March 2026. Nestled in our beautiful local open spaces, these tours offer a great way to learn about local agriculture and nature. You can find more information about exploring our parks and open spaces on the [City of Mountain View website](https://mountainview.gov/).
+
+### Neighborhood Update: The Final Block Party
+
+Lastly, as many of you have seen discussed on the [rex-manor-neighbors Google Group](https://groups.google.com/g/rex-manor-neighbors), we have an official date for our annual neighborhood gathering. Please mark your calendars: our **Final Neighborhood Block Party** will be held on **Sunday, June 7, 2026**.
+
+While it is bittersweet that this will be the last of these specific block parties, we are looking forward to making it the best one yet. Please continue to check the Google Group for updates on planning and volunteer opportunities.
+
+Have a fantastic March!
+
+— David Watson


### PR DESCRIPTION
This PR adds a new blog post for March 2026 events and updates.

- Added `content/news/2026-03-events-and-updates.md`.
- Curated local events including TechFest (CHM), Repair Café (Hacker Dojo), Newsies (MVCPA), and Deer Hollow Farm tours.
- Included community news about the Final Neighborhood Block Party based on the Google Group discussion.
- Ensured a positive, pro-tech, and anti-NIMBY tone in line with the authorial voice guidelines.

---
*PR created automatically by Jules for task [14177146683543355072](https://jules.google.com/task/14177146683543355072) started by @davidfwatson*