### PR TITLE
Add April 2026 events blog post

### DIFF
--- a/content/news/2026-04-april-events.md
+++ b/content/news/2026-04-april-events.md
@@ -1,0 +1,33 @@
+---
+title: "April in Mountain View: Spring Events and Community Connections"
+date: 2026-04-01
+summary: "Welcome to April! Get ready for the return of Music on Castro, innovative events at the Hacker Dojo, and an important update on our Rex Manor Block Party."
+---
+
+Happy April, neighbors!
+
+Spring is fully upon us, and with the longer days and warmer weather, Mountain View is bustling with fantastic community events. It’s a wonderful time to get out, enjoy our beautiful city, and connect with neighbors. Here are some highlights to look forward to this month:
+
+### Music on Castro Returns!
+
+I am thrilled to share that the **[Music on Castro](https://www.mountainview.gov/our-city/departments/community-services/music-on-castro)** series returns to Downtown Mountain View starting this month! From April through October, you can enjoy live performances every Wednesday from **5:00 PM to 6:45 PM**.
+
+The performances take place on the 200 block of Castro Street, close to the Dana Street intersection. It's the perfect opportunity to make it a midweek tradition, listen to dynamic local and regional talent, and support our fantastic downtown shops and restaurants. The April lineup kicks off on **April 1** with Sambo to Samba.
+
+### Hacker Dojo: Build & Chill Project Jam
+
+Our local tech community continues to be a massive positive force in Mountain View, fostering innovation and collaboration. For those interested in creating and tinkering, the **[Hacker Dojo](https://hackerdojo.com/)** (855 Maude Ave) is hosting a **"Build & Chill Project Jam"** on Wednesday, **April 1, 2026, from 7:00 PM to 9:00 PM**.
+
+This is a recurring event every two weeks where innovators, creatives, and builders can drop in, collaborate on projects, or just hang out and see what’s happening in the local tech scene. It’s a low-pressure environment that perfectly captures the collaborative spirit of Silicon Valley. Whether you bring your laptop, some tools, or just a curious mind, it’s a great way to get involved.
+
+### Rex Manor Block Party: Planning Continues
+
+As mentioned in previous updates, planning for our **Rex Manor Annual Block Party** (scheduled for **Sunday, June 7, 2026**) is in full swing!
+
+Thank you to everyone who has already stepped up. We still need plenty of volunteers to help with everything from passing out flyers to organizing games and activities. It takes a village to make this event successful year after year.
+
+Please continue to join the conversation and sign up to volunteer on our **[rex-manor-neighbors Google Group](https://groups.google.com/g/rex-manor-neighbors)**. It is the best place to stay updated on block party news, as well as other important neighborhood discussions.
+
+Let's make this April a great one!
+
+— David Watson


### PR DESCRIPTION
Added a new blog post for April 2026 covering Music on Castro, the Hacker Dojo Build & Chill Project Jam, and the Rex Manor Block Party planning updates, adhering to all neighborhood bulletin guidelines.

---
*PR created automatically by Jules for task [8784268075443747739](https://jules.google.com/task/8784268075443747739) started by @davidfwatson*