### PR TITLE
Add April events and block party planning blog post

### DIFF
--- a/content/news/2026-04-april-updates.md
+++ b/content/news/2026-04-april-updates.md
@@ -1,0 +1,23 @@
+---
+title: "Mid-April Updates: Global Tech in Mountain View and Block Party Planning"
+date: 2026-04-11
+summary: "April continues with exciting global tech events at the Computer History Museum and an important reminder to help plan our upcoming neighborhood block party."
+---
+
+Hello neighbors,
+
+As we head into the middle of April, it is wonderful to see our city blooming and continuing to host events that put Mountain View on the map. Our local tech scene remains a driving force for positive connection and innovation right in our backyard.
+
+### Wi-Fi World Congress USA 2026
+
+We are incredibly lucky to have the [Computer History Museum](https://computerhistory.org/) as a central hub for global technology gatherings. From April 13 to April 15, the museum is hosting the [Wi-Fi World Congress USA 2026](https://wifinowglobal.com/usa-2026/). This premier industry event brings together experts from around the world to discuss the latest innovations in wireless technology. It is a fantastic reminder of how the tech industry brings brilliant minds to our city and continues to shape the future of global connectivity.
+
+### Neighborhood Life
+
+As a quick reminder, our annual Rex Manor Neighborhood Block Party is coming up on Sunday, June 7, 2026! Thank you to everyone who has already stepped up to help. We are still looking for more volunteers to assist with preparations, including passing out flyers to the neighborhood and making sure we have everything we need for a successful event.
+
+If you are interested in volunteering or want to stay updated on the planning process, please check out the discussions on our [rex-manor-neighbors Google Group](https://groups.google.com/g/rex-manor-neighbors).
+
+Enjoy the rest of your weekend!
+
+— David Watson


### PR DESCRIPTION
This commit adds a new blog post (`content/news/2026-04-april-updates.md`) highlighting upcoming April events in Mountain View. It features the Wi-Fi World Congress USA 2026 at the Computer History Museum to emphasize the positive impact of the local tech industry. It also includes an important neighborhood update regarding planning and volunteer opportunities for the upcoming Rex Manor Neighborhood Block Party on June 7, 2026, as sourced from the rex-manor-neighbors Google Group.

The post is authored from the perspective of David Watson and maintains a positive, pro-tech, and community-focused tone, strictly adhering to the provided instructions and omitting any mention of the block party being the "last" one.

---
*PR created automatically by Jules for task [6387491279358310136](https://jules.google.com/task/6387491279358310136) started by @davidfwatson*