### PR TITLE
Add Mid-April Events Blog Post

### DIFF
--- a/content/news/2026-04-spring-events.md
+++ b/content/news/2026-04-spring-events.md
@@ -1,0 +1,29 @@
+---
+title: "Mid-April Updates: Arts, Tech, and Our Block Party!"
+date: 2026-04-18
+summary: "Get the latest on what's happening around Mountain View this April, from amazing local theater and tech meetups to our upcoming neighborhood block party."
+---
+
+Hello neighbors,
+
+I hope you're all enjoying a wonderful spring! As we hit the middle of April, there are some fantastic events coming up in Mountain View that highlight the diverse and vibrant character of our city. Whether you're a fan of the arts, excited about the latest in technology, or just looking forward to some neighborhood fun, there is something for everyone.
+
+### Arts and Culture
+
+If you're looking for an uplifting night out, the hit musical *Come From Away* is currently running through early May at the [Mountain View Center for the Performing Arts](https://tickets.mvcpa.com/). It's a wonderful, heartwarming true story, and having such incredible theater right here in our city is a great privilege.
+
+### Celebrating Technology in Our City
+
+As always, Mountain View continues to be a thriving hub of innovation, and we are lucky to have so many opportunities to engage with the tech industry right in our backyard.
+
+On Thursday, April 30, the Hacker Dojo (855 Maude Avenue) is hosting the [Mindstone Silicon Valley April AI Meetup](https://community.mindstone.com/events/mindstone-silicon-valley-april-ai-meetup-2026). This is a fantastic opportunity to hear from builders working with Artificial Intelligence, connect with others, and learn about the positive impact AI will have on our work and society.
+
+Additionally, the [Computer History Museum](https://computerhistory.org/events/) will be holding its 2026 Fellow Awards Ceremony on Saturday, April 25. It's a great reminder of the rich technological history of our region and the pioneers who paved the way for the incredible growth and advancements we see today.
+
+### Neighborhood Life
+
+Finally, please mark your calendars! The Rex Manor Neighborhood Block Party is scheduled for Sunday, June 7, 2026. My wife and I will be helping to organize it this year, and we're looking forward to seeing everyone there for a great afternoon. I also want to give a quick shout-out and thank you to Michael Woods for his generous offer to help write the neighborhood block party grant application this year—community involvement like this is what makes Rex Manor such a wonderful place to live.
+
+Wishing you all a fantastic rest of the month!
+
+— David Watson


### PR DESCRIPTION
This commit adds a new blog post written by David Watson summarizing mid-April events in Mountain View. It includes details about the 'Come From Away' musical at MVCPA, an AI Meetup at Hacker Dojo, the 2026 Fellow Awards at the Computer History Museum, and a reminder about the upcoming Rex Manor Neighborhood Block Party. The post maintains a positive, pro-tech tone and avoids any mention of the block party being the 'last' or 'final' one.

---
*PR created automatically by Jules for task [16391042694665462633](https://jules.google.com/task/16391042694665462633) started by @davidfwatson*