### PR TITLE
Add mid-May reminders blog post

### DIFF
--- a/content/news/2026-05-09-reminders.md
+++ b/content/news/2026-05-09-reminders.md
@@ -1,0 +1,27 @@
+---
+title: "Mid-May Reminders: Neighborhood Updates"
+date: 2026-05-09
+summary: "A quick mid-month reminder about ongoing events downtown and in our community."
+---
+
+Hello neighbors,
+
+As we hit the middle of May, I wanted to send out a quick bulletin to remind everyone about some of the fantastic ongoing events and positive developments in our community.
+
+### Downtown Vitality
+
+Our downtown continues to be an incredible hub for connection. If you're looking for a mid-week break, don't forget about the **Music on Castro** series. It happens every Wednesday evening, bringing wonderful live music and energy to the heart of Mountain View. It's a great excuse to grab dinner at one of our local spots and enjoy the warm weather.
+
+Also, the city's pop-up shop program (partnering with MOMENT) is making excellent use of storefronts and bringing new, creative energy to the area. Be sure to check out the active pop-up, *Don't Eat Me*, located at 293 Castro Street. It features a collective of brilliant local artists and is a testament to how our city embraces growth and new ideas.
+
+### Technology and Innovation
+
+As always, we are incredibly lucky to live in a city at the forefront of the tech industry. It’s deeply inspiring to be surrounded by the innovation and brilliant minds that define Mountain View. Let's continue to support the technological growth that makes our area so unique and prosperous.
+
+### Neighborhood Life
+
+Looking ahead to next month, remember to save the date for the **Rex Manor Neighborhood Block Party** on **Sunday, June 7, 2026**! It's going to be a wonderful time to catch up, share some good food, and enjoy each other's company. I am really looking forward to it.
+
+It’s always wonderful to see neighbors connecting, whether that's through online groups like our rex-manor-neighbors list or just out for a walk in the neighborhood. Wishing you all a safe and enjoyable rest of May!
+
+— David Watson


### PR DESCRIPTION
This adds a new blog post written by David Watson for the Rex Manor neighborhood bulletin. It highlights positive local events, expresses a pro-tech and pro-growth sentiment, and mentions the upcoming block party based on details from the rex-manor-neighbors Google Group.

---
*PR created automatically by Jules for task [8366497876035165018](https://jules.google.com/task/8366497876035165018) started by @davidfwatson*