### PR TITLE
Add late May 2026 updates blog post

### DIFF
--- a/content/news/2026-05-late-updates.md
+++ b/content/news/2026-05-late-updates.md
@@ -1,0 +1,27 @@
+---
+title: "Late May Updates: Celebrating Innovation and Community"
+date: 2026-05-23
+summary: "As we head into the end of May, let's celebrate our local tech history and gear up for upcoming neighborhood gatherings."
+---
+
+Hello neighbors,
+
+As we near the end of May, I wanted to share a few updates and highlight some fantastic events happening right in our own backyard. Our city is constantly evolving, bringing new opportunities to connect, learn, and celebrate together!
+
+### Celebrating Tech and Innovation
+
+We are incredibly fortunate to live in a hub of innovation, and the [Computer History Museum (CHM)](https://computerhistory.org/) is a testament to the incredible legacy of the tech industry here.
+
+I want to highlight the upcoming **2026 CHM Awards Ceremony**. This gala celebration honors new Fellows and a Silicon Valley Laureate, emphasizing the teamwork and collaboration behind lasting technological success. It’s a wonderful reminder of the positive impact our local industry has globally.
+
+While you're checking out CHM, be sure to read about their fascinating **A Historic Pixel Art Exhibition** on the CHM Blog. It tells the story of a groundbreaking 1981 show featuring digital art on monitors connected to framebuffers. It’s incredible to see how far technology has come, thanks to the pioneering small teams that pulled off such early feats!
+
+### Neighborhood Life
+
+A quick reminder that the **[Music on Castro](https://www.mountainview.gov/our-city/departments/community-services/music-on-castro)** series is ongoing every Wednesday evening downtown. It’s always a delight to see our community vibrant and active, enjoying live music.
+
+Also, don't forget to mark your calendars for the upcoming **Rex Manor Annual Block Party** on Sunday, June 7! It’s the perfect time to catch up with old friends and welcome new neighbors as our community continues to grow.
+
+Have a wonderful rest of the month!
+
+— David Watson


### PR DESCRIPTION
This adds a new post to the Rex Manor neighborhood bulletin about late May and June events in Mountain View. Included are the CHM 2026 Awards Ceremony, the CHM Historical Pixel Art Exhibition, Music on Castro, and the Rex Manor Annual Block Party. The tone is positive, pro-tech, and signed by David Watson.

---
*PR created automatically by Jules for task [15235551056887705584](https://jules.google.com/task/15235551056887705584) started by @davidfwatson*