### PR TITLE
Add block party volunteer signup page

### DIFF
--- a/config/_default/menus.en.toml
+++ b/config/_default/menus.en.toml
@@ -35,6 +35,11 @@
   url = "/join/"
   weight = 50
 
+[[main]]
+  name = "Volunteer"
+  url = "/volunteer/"
+  weight = 60
+
 #[[main]]
 #  name = "Blog"
 #  pageRef = "posts"

--- a/content/volunteer/_index.md
+++ b/content/volunteer/_index.md
@@ -1,0 +1,43 @@
+---
+title: "Volunteer to Help with the Neighborhood Block Party"
+date: 2026-06-07
+---
+
+Our annual block party only happens because neighbors pitch in. If you can lend a hand—before, during, or after the event—please sign up below and we'll be in touch with the details.
+
+Just your name plus a phone number or email is enough. The "I can help with" boxes are optional—check whatever you're up for.
+
+<form action="/volunteer/submit" method="post" style="max-width:560px;margin-top:1.5rem;">
+  <div style="margin-bottom:1.1rem;">
+    <label for="vol-name" style="display:block;font-weight:600;margin-bottom:.35rem;">Name <span style="color:#dc2626;">*</span></label>
+    <input id="vol-name" name="name" type="text" required autocomplete="name"
+           style="width:100%;padding:.6rem .7rem;border:1px solid #cbd5e1;border-radius:.5rem;font-size:1rem;box-sizing:border-box;">
+  </div>
+
+  <div style="margin-bottom:1.1rem;">
+    <label for="vol-phone" style="display:block;font-weight:600;margin-bottom:.35rem;">Phone</label>
+    <input id="vol-phone" name="phone" type="tel" autocomplete="tel"
+           style="width:100%;padding:.6rem .7rem;border:1px solid #cbd5e1;border-radius:.5rem;font-size:1rem;box-sizing:border-box;">
+  </div>
+
+  <div style="margin-bottom:1.1rem;">
+    <label for="vol-email" style="display:block;font-weight:600;margin-bottom:.35rem;">Email</label>
+    <input id="vol-email" name="email" type="email" autocomplete="email"
+           style="width:100%;padding:.6rem .7rem;border:1px solid #cbd5e1;border-radius:.5rem;font-size:1rem;box-sizing:border-box;">
+  </div>
+  <p style="font-size:.9rem;color:#6b7280;margin-top:-.6rem;">Please give us a phone number or an email so we can reach you.</p>
+
+  <fieldset style="border:1px solid #e5e7eb;border-radius:.5rem;padding:1rem 1.1rem;margin:1.25rem 0;">
+    <legend style="font-weight:600;padding:0 .4rem;">I can help with (optional)</legend>
+    <label style="display:block;margin:.4rem 0;"><input type="checkbox" name="help" value="setup" style="margin-right:.5rem;">Set up chairs / tables</label>
+    <label style="display:block;margin:.4rem 0;"><input type="checkbox" name="help" value="cook" style="margin-right:.5rem;">Cook</label>
+    <label style="display:block;margin:.4rem 0;"><input type="checkbox" name="help" value="fliers" style="margin-right:.5rem;">Distribute fliers</label>
+    <label style="display:block;margin:.4rem 0;"><input type="checkbox" name="help" value="teardown" style="margin-right:.5rem;">Tear down</label>
+    <label style="display:block;margin:.4rem 0;"><input type="checkbox" name="help" value="pickup" style="margin-right:.5rem;">Pick up food day before</label>
+  </fieldset>
+
+  <button type="submit"
+          style="background:#2563eb;color:#fff;border:none;padding:.7rem 1.4rem;border-radius:.5rem;font-size:1rem;font-weight:600;cursor:pointer;">
+    Sign me up
+  </button>
+</form>


### PR DESCRIPTION
Adds a **Volunteer to help with the neighborhood block party** section to the site.

## What's here
- New `/volunteer/` page with a signup form: **name** (required), **phone**, **email** (a phone or email is required), plus an optional **"I can help with"** checklist:
  - Set up chairs / tables
  - Cook
  - Distribute fliers
  - Tear down
  - Pick up food day before
- New **Volunteer** entry in the main menu.

## Backend (server-side, not in this repo)
The form POSTs to `/volunteer/submit`, which nginx proxies via a uWSGI unix socket to a small Flask service at `~/webserver/block-party-volunteer/`. Signups are stored in a local SQLite database (`data/volunteers.db`). The service runs under systemd (`block-party-volunteer.service`) and starts on boot. `export.py` dumps signups to CSV.

🤖 Generated with [Claude Code](https://claude.com/claude-code)