### PR TITLE
Add "Food prep day before" and "Other" to volunteer form

### DIFF
--- a/content/volunteer/_index.md
+++ b/content/volunteer/_index.md
@@ -34,6 +34,11 @@ Just your name plus a phone number or email is enough. The "I can help with" box
     <label style="display:block;margin:.4rem 0;"><input type="checkbox" name="help" value="fliers" style="margin-right:.5rem;">Distribute fliers</label>
     <label style="display:block;margin:.4rem 0;"><input type="checkbox" name="help" value="teardown" style="margin-right:.5rem;">Tear down</label>
     <label style="display:block;margin:.4rem 0;"><input type="checkbox" name="help" value="pickup" style="margin-right:.5rem;">Pick up food day before</label>
+    <label style="display:block;margin:.4rem 0;"><input type="checkbox" name="help" value="foodprep" style="margin-right:.5rem;">Food prep day before</label>
+    <label style="display:block;margin:.4rem 0;"><input type="checkbox" name="help" value="other" style="margin-right:.5rem;">Other:
+      <input type="text" name="other_text" aria-label="Other — please specify" placeholder="please specify"
+             style="margin-left:.4rem;padding:.35rem .55rem;border:1px solid #cbd5e1;border-radius:.4rem;font-size:.95rem;">
+    </label>
   </fieldset>
 
   <button type="submit"


### PR DESCRIPTION
Adds two more options to the **"I can help with"** checklist on the [volunteer signup page](https://rexmanor.org/volunteer/):

- **Food prep day before**
- **Other** — with a free-text blank so volunteers can write in something not listed

The Flask/SQLite backend (on the server) was updated to store the new `foodprep` and `other` keys plus the free-text value (new `other_text` column, with an in-place migration for the existing DB). CSV export includes an "other (specify)" column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)