### PR TITLE
Move volunteer signup Flask service into the site repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,13 @@ my-hugo-site/resources/
 docs/
 hugo.log
 *.log
+
+# Volunteer signup Flask service (volunteer/): track the code, never the
+# venvs, the SQLite DB (real signups — PII), or the roster snapshot (PII).
+# This repo is public.
+volunteer/venv/
+volunteer/sheets-venv/
+volunteer/data/
+volunteer/__pycache__/
+volunteer/*.sock
+volunteer/sheet_snapshot.md

--- a/volunteer/README.md
+++ b/volunteer/README.md
@@ -1,0 +1,42 @@
+# Block Party Volunteer Signup Service
+
+Small Flask/uWSGI app behind nginx that backs the **Volunteer** page on the
+Hugo site (`content/volunteer/_index.md`). The form POSTs to `/volunteer/submit`;
+nginx proxies that to this app over a unix socket, and signups are stored in a
+local SQLite DB.
+
+## Layout
+
+| File | Purpose |
+|------|---------|
+| `app.py` | Flask app: validates and stores signups (`/volunteer/submit`). |
+| `volunteer.ini` | uWSGI config (socket at `volunteer/volunteer.sock`). |
+| `rex-manor-volunteer.service` | systemd unit (copy to `/etc/systemd/system/`). |
+| `export.py` | Dump signups to CSV on stdout. |
+| `import_sheet.py` | One-off: import the organizers' Google Sheet roster into the DB. |
+| `db_to_sheet.py` | Push website signups up to a "Website Signups" tab in the sheet. |
+
+## Not in git (gitignored — this repo is public)
+
+- `venv/`, `sheets-venv/` — virtualenvs (rebuild from `requirements.txt`).
+- `data/` — the SQLite DB and backups (**real signups, PII**).
+- `sheet_snapshot.md` — copy of the roster sheet (**PII**).
+
+## Common tasks
+
+```bash
+# Export signups to CSV
+./venv/bin/python export.py > signups.csv
+
+# Refresh the "Website Signups" tab in the Google Sheet (manual, not automated)
+./sheets-venv/bin/python db_to_sheet.py
+
+# Service control
+sudo systemctl {status,restart} rex-manor-volunteer.service
+```
+
+## Google Sheets auth
+
+`db_to_sheet.py` reuses the existing `linode-mv-yimby@…` service account key at
+`/home/david/james-form/service-account.json`. The target sheet must be shared
+with that service account's `client_email` as Editor.

--- a/volunteer/app.py
+++ b/volunteer/app.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""
+Rex Manor Block Party — Volunteer signup service.
+
+Collects volunteer signups (name, phone, email, and optional "I can help with"
+checkboxes) from the rexmanor.org website and stores them in a local SQLite DB.
+
+The signup form itself is a static Hugo page at /volunteer/ on rexmanor.org.
+That form POSTs to /volunteer/submit, which nginx proxies to this app via a
+uWSGI unix socket.
+"""
+
+import json
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+
+from flask import Flask, request, Response
+from markupsafe import escape
+
+BASE_DIR = Path(__file__).resolve().parent
+DB_PATH = BASE_DIR / "data" / "volunteers.db"
+
+# Canonical list of help options. Keys are stored; labels are shown on the form.
+HELP_OPTIONS = [
+    ("setup", "Set up chairs / tables"),
+    ("cook", "Cook"),
+    ("fliers", "Distribute fliers"),
+    ("teardown", "Tear down"),
+    ("pickup", "Pick up food day before"),
+    ("foodprep", "Food prep day before"),
+    ("other", "Other"),
+]
+VALID_HELP_KEYS = {key for key, _ in HELP_OPTIONS}
+
+app = Flask(__name__)
+
+
+def init_db():
+    """Create the volunteers table if it does not exist."""
+    DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS volunteers (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL,
+                phone TEXT,
+                email TEXT,
+                help TEXT,
+                other_text TEXT,
+                created_at TEXT NOT NULL
+            )
+            """
+        )
+        # Migrate older DBs that predate the free-text "Other" field.
+        cols = {row[1] for row in conn.execute("PRAGMA table_info(volunteers)")}
+        if "other_text" not in cols:
+            conn.execute("ALTER TABLE volunteers ADD COLUMN other_text TEXT")
+        conn.commit()
+
+
+init_db()
+
+
+def page(title, body):
+    """Wrap a fragment of HTML in a minimal styled response page."""
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{escape(title)} — Rex Manor Block Party</title>
+  <style>
+    body {{ font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+           max-width: 640px; margin: 4rem auto; padding: 0 1.25rem; line-height: 1.6; color: #1f2937; }}
+    h1 {{ font-size: 1.6rem; }}
+    a.button {{ display: inline-block; margin-top: 1.5rem; padding: 0.6rem 1.2rem;
+               background: #2563eb; color: #fff; border-radius: 0.5rem; text-decoration: none; }}
+    .card {{ background: #f9fafb; border: 1px solid #e5e7eb; border-radius: 0.75rem; padding: 1.5rem 1.75rem; }}
+  </style>
+</head>
+<body>
+  <div class="card">
+    {body}
+  </div>
+</body>
+</html>"""
+
+
+@app.route("/volunteer/submit", methods=["POST"])
+def submit():
+    name = (request.form.get("name") or "").strip()
+    phone = (request.form.get("phone") or "").strip()
+    email = (request.form.get("email") or "").strip()
+    help_keys = [k for k in request.form.getlist("help") if k in VALID_HELP_KEYS]
+    other_text = (request.form.get("other_text") or "").strip()
+    # If they typed something in the "Other" blank, treat that as opting in.
+    if other_text and "other" not in help_keys:
+        help_keys.append("other")
+
+    # Validation: a name plus at least one way to reach them.
+    errors = []
+    if not name:
+        errors.append("Please enter your name.")
+    if not phone and not email:
+        errors.append("Please provide a phone number or an email address so we can reach you.")
+
+    if errors:
+        items = "".join(f"<li>{escape(e)}</li>" for e in errors)
+        body = (
+            "<h1>Hold on a sec…</h1>"
+            f"<ul>{items}</ul>"
+            '<a class="button" href="/volunteer/">Back to the form</a>'
+        )
+        return Response(page("Please fix a couple things", body), status=400, mimetype="text/html")
+
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.execute(
+            "INSERT INTO volunteers (name, phone, email, help, other_text, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                name,
+                phone,
+                email,
+                json.dumps(help_keys),
+                other_text,
+                datetime.now(timezone.utc).isoformat(),
+            ),
+        )
+        conn.commit()
+
+    body = (
+        f"<h1>Thank you, {escape(name)}! 🎉</h1>"
+        "<p>You're signed up to help with the Rex Manor neighborhood block party. "
+        "We'll be in touch with details closer to the event.</p>"
+        '<a class="button" href="https://rexmanor.org/">Back to the website</a>'
+    )
+    return Response(page("Thank you!", body), mimetype="text/html")
+
+
+@app.route("/volunteer/health", methods=["GET"])
+def health():
+    return Response("ok", mimetype="text/plain")
+
+
+if __name__ == "__main__":
+    app.run(host="127.0.0.1", port=5099, debug=True)

--- a/volunteer/db_to_sheet.py
+++ b/volunteer/db_to_sheet.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""
+Push website volunteer signups (source='web' rows in the SQLite DB) up to the
+organizers' Google Sheet, into a dedicated "Website Signups" tab so the master
+roster layout is never touched.
+
+Auth: a Google service-account key. Point SA_KEY at the JSON file (default:
+./service-account.json) and share the spreadsheet with the service account's
+email (as Editor).
+
+Run:  ./sheets-venv/bin/python db_to_sheet.py
+"""
+import json
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+from google.oauth2.service_account import Credentials
+from googleapiclient.discovery import build
+
+BASE = Path(__file__).resolve().parent
+DB = BASE / "data" / "volunteers.db"
+# Reuses the existing "linode-mv-yimby" service account (shared with james-form);
+# the block party sheet must be shared with its client_email as Editor.
+SA_KEY = Path(os.environ.get("SA_KEY", "/home/david/james-form/service-account.json"))
+SPREADSHEET_ID = "1UPkPZF2vvvV1WHP1XKYBWRUF3bFPTs0dnauwELL4Aiw"
+TAB = "Website Signups"
+SCOPES = ["https://www.googleapis.com/auth/spreadsheets"]
+
+HELP_LABELS = {
+    "setup": "Set up chairs / tables",
+    "cook": "Cook",
+    "fliers": "Distribute fliers",
+    "teardown": "Tear down",
+    "pickup": "Pick up food day before",
+    "foodprep": "Food prep day before",
+    "other": "Other",
+}
+
+
+def rows_from_db():
+    conn = sqlite3.connect(DB)
+    out = []
+    for r in conn.execute(
+        "SELECT name, COALESCE(address,''), phone, email, help, "
+        "COALESCE(other_text,''), created_at "
+        # 'web' and 'web+sheet' = signed up via the website (latter also in the
+        # master roster after a merge). Pure 'sheet' rows are excluded.
+        "FROM volunteers WHERE COALESCE(source,'web') LIKE 'web%' ORDER BY id"
+    ):
+        name, addr, phone, email, help_json, other, created = r
+        keys = json.loads(help_json or "[]")
+        can_help = "; ".join(HELP_LABELS.get(k, k) for k in keys)
+        notes = other.strip()
+        out.append([name, addr, phone, email, can_help, notes, created])
+    return out
+
+
+def get_service():
+    if not SA_KEY.exists():
+        sys.exit(f"Service-account key not found at {SA_KEY}. "
+                 f"Set SA_KEY or place the JSON there.")
+    creds = Credentials.from_service_account_file(str(SA_KEY), scopes=SCOPES)
+    sa_email = json.load(open(SA_KEY)).get("client_email", "?")
+    print(f"Authenticating as service account: {sa_email}")
+    return build("sheets", "v4", credentials=creds, cache_discovery=False)
+
+
+def ensure_tab(svc):
+    meta = svc.spreadsheets().get(spreadsheetId=SPREADSHEET_ID).execute()
+    titles = [s["properties"]["title"] for s in meta["sheets"]]
+    if TAB not in titles:
+        svc.spreadsheets().batchUpdate(
+            spreadsheetId=SPREADSHEET_ID,
+            body={"requests": [{"addSheet": {"properties": {"title": TAB}}}]},
+        ).execute()
+        print(f"Created tab '{TAB}'.")
+    else:
+        print(f"Tab '{TAB}' already exists; refreshing it.")
+
+
+def main():
+    svc = get_service()
+    ensure_tab(svc)
+    rows = rows_from_db()
+    header = ["Name", "Address", "Cell Number", "email",
+              "Can help with", "Notes / other", "Signed up (UTC)"]
+    values = [header] + rows
+    # Clear then write, so re-runs stay idempotent.
+    svc.spreadsheets().values().clear(
+        spreadsheetId=SPREADSHEET_ID, range=f"'{TAB}'!A1:Z10000"
+    ).execute()
+    svc.spreadsheets().values().update(
+        spreadsheetId=SPREADSHEET_ID,
+        range=f"'{TAB}'!A1",
+        valueInputOption="RAW",
+        body={"values": values},
+    ).execute()
+    print(f"Wrote {len(rows)} website signups to the '{TAB}' tab.")
+    print(f"https://docs.google.com/spreadsheets/d/{SPREADSHEET_ID}/edit")
+
+
+if __name__ == "__main__":
+    main()

--- a/volunteer/export.py
+++ b/volunteer/export.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Dump volunteer signups to CSV on stdout.  Usage: python3 export.py"""
+import csv
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+DB_PATH = Path(__file__).resolve().parent / "data" / "volunteers.db"
+HELP_LABELS = {
+    "setup": "Set up chairs / tables",
+    "cook": "Cook",
+    "fliers": "Distribute fliers",
+    "teardown": "Tear down",
+    "pickup": "Pick up food day before",
+    "foodprep": "Food prep day before",
+    "other": "Other",
+}
+
+with sqlite3.connect(DB_PATH) as conn:
+    rows = conn.execute(
+        "SELECT id, name, phone, email, help, other_text, created_at FROM volunteers ORDER BY id"
+    ).fetchall()
+
+writer = csv.writer(sys.stdout)
+writer.writerow(
+    ["id", "name", "phone", "email", "can help with", "other (specify)", "signed up (UTC)"]
+)
+for r in rows:
+    help_keys = json.loads(r[4] or "[]")
+    help_str = "; ".join(HELP_LABELS.get(k, k) for k in help_keys)
+    writer.writerow([r[0], r[1], r[2], r[3], help_str, r[5], r[6]])

--- a/volunteer/import_sheet.py
+++ b/volunteer/import_sheet.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""
+One-off: import the organizers' master volunteer roster (Google Sheet) into the
+volunteers SQLite DB, merging with existing website signups.
+
+- Parses only the people-tables from sheet_snapshot.md (the main roster, the
+  Barron/Lambert mini-table, and the veg-prep assignment table). Ignores the
+  job-definition, prep-checklist and shopping-list tables.
+- Dedups within the sheet by email -> phone(last10) -> normalized name.
+- Merges into the DB: if a sheet person matches an existing row (by email, phone
+  or name) the existing row is kept and only its EMPTY fields are filled in;
+  otherwise a new row is inserted with source='sheet'.
+"""
+import re
+import sqlite3
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+BASE = Path(__file__).resolve().parent
+DB = BASE / "data" / "volunteers.db"
+SNAP = BASE / "sheet_snapshot.md"
+
+# Rows in the main table that are section headers / non-people, not volunteers.
+SKIP_NAMES = {"cut up fruit and vegetables", "name(s)", ""}
+
+
+def norm_name(n):
+    return re.sub(r"\s+", " ", (n or "").strip().lower())
+
+
+def norm_phone(p):
+    d = re.sub(r"\D", "", p or "")
+    return d[-10:] if len(d) >= 10 else ""
+
+
+def norm_email(e):
+    e = (e or "").strip().lower()
+    return e if "@" in e else ""
+
+
+def split_row(line):
+    # "| a | b | c |" -> ["a","b","c"]
+    cells = [c.strip() for c in line.strip().strip("|").split("|")]
+    return cells
+
+
+class Person:
+    def __init__(self, name):
+        self.name = name.strip()
+        self.address = ""
+        self.phone = ""
+        self.email = ""
+        self.jobs = []   # "jobs taken previously" + prep tasks
+        self.notes = []  # free-form notes
+
+    def absorb(self, address="", phone="", email="", job="", note=""):
+        if address and not self.address:
+            self.address = address
+        if phone and not self.phone:
+            self.phone = phone
+        if email and not self.email:
+            self.email = email
+        if job and job not in self.jobs:
+            self.jobs.append(job)
+        if note and note not in self.notes:
+            self.notes.append(note)
+
+    def key(self):
+        return norm_email(self.email) or norm_phone(self.phone) or norm_name(self.name)
+
+
+def parse():
+    text = SNAP.read_text()
+    people = {}  # key -> Person
+
+    def get(person_name):
+        # find existing person by identity, else create
+        return person_name  # placeholder; resolved in upsert()
+
+    pending = []  # (name, address, phone, email, job, note)
+
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line.startswith("|"):
+            continue
+        cells = split_row(line)
+        if not cells or all(c == "" or set(c) <= {":", "-"} for c in cells):
+            continue
+        name = cells[0].strip()
+        if norm_name(name) in SKIP_NAMES:
+            continue
+        if set(cells[0]) <= {":", "-"}:  # separator row
+            continue
+
+        address = phone = email = job = note = ""
+        n = len(cells)
+        if n >= 6:                       # main roster table
+            address, c2, c3, job = cells[1], cells[2], cells[3], cells[4]
+            note = cells[5]
+            # c2 is "Cell Number", c3 is "email" -- but data is sometimes misaligned
+            email_field = c3
+            if "@" in email_field:
+                email = email_field
+            elif email_field:           # not an email -> it's really a note
+                note = (note + "; " + email_field).strip("; ")
+            phone = c2
+        elif n == 5:                     # veg-prep assignment table
+            address, phone, email, job = cells[1], cells[2], cells[3], cells[4]
+        elif n == 3:                     # Barron / Lambert mini-table
+            address, phone = cells[1], cells[2]
+        else:
+            continue
+        pending.append((name, address, phone, email, job, note))
+
+    # Build deduped people, resolving identity progressively.
+    for name, address, phone, email, job, note in pending:
+        ek, pk, nk = norm_email(email), norm_phone(phone), norm_name(name)
+        match = None
+        for k, p in people.items():
+            if (ek and norm_email(p.email) == ek) or \
+               (pk and norm_phone(p.phone) == pk) or \
+               (nk and norm_name(p.name) == nk):
+                match = p
+                break
+        if match is None:
+            match = Person(name)
+            people[match.key() or nk or name] = match
+        match.absorb(address, phone, email, job, note)
+    return list(people.values())
+
+
+def main():
+    people = parse()
+    conn = sqlite3.connect(DB)
+
+    # schema: add columns used by the sheet import (safe if already present)
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(volunteers)")}
+    for col in ("address", "notes", "source"):
+        if col not in cols:
+            conn.execute(f"ALTER TABLE volunteers ADD COLUMN {col} TEXT")
+    conn.execute("UPDATE volunteers SET source='web' WHERE source IS NULL")
+    conn.commit()
+
+    existing = conn.execute(
+        "SELECT id, name, phone, email, address, notes FROM volunteers"
+    ).fetchall()
+
+    def find_match(p):
+        ek, pk, nk = norm_email(p.email), norm_phone(p.phone), norm_name(p.name)
+        for row in existing:
+            rid, rname, rphone, remail, raddr, rnotes = row
+            if (ek and norm_email(remail) == ek) or \
+               (pk and norm_phone(rphone) == pk) or \
+               (nk and norm_name(rname) == nk):
+                return row
+        return None
+
+    inserted, enriched, matched_clean = [], [], []
+    now = datetime.now(timezone.utc).isoformat()
+
+    for p in people:
+        notes_str = "; ".join(p.jobs + p.notes).strip("; ")
+        row = find_match(p)
+        if row:
+            rid, rname, rphone, remail, raddr, rnotes = row
+            fills = {}
+            if p.email and not norm_email(remail):
+                fills["email"] = p.email
+            if p.phone and not norm_phone(rphone):
+                fills["phone"] = p.phone
+            if p.address and not (raddr or ""):
+                fills["address"] = p.address
+            # append sheet jobs/notes to whatever notes exist
+            if notes_str:
+                merged = "; ".join(x for x in [(rnotes or ""), notes_str] if x).strip("; ")
+                fills["notes"] = merged
+            if fills:
+                sets = ", ".join(f"{k}=?" for k in fills)
+                conn.execute(f"UPDATE volunteers SET {sets} WHERE id=?",
+                             (*fills.values(), rid))
+                enriched.append((rname, p.name, list(fills)))
+            else:
+                matched_clean.append((rname, p.name))
+        else:
+            conn.execute(
+                "INSERT INTO volunteers (name, phone, email, help, other_text, "
+                "address, notes, source, created_at) VALUES (?,?,?,?,?,?,?,?,?)",
+                (p.name, p.phone, p.email, "[]", "", p.address, notes_str, "sheet", now),
+            )
+            inserted.append(p.name)
+    conn.commit()
+
+    print(f"Parsed {len(people)} unique people from the sheet.\n")
+    print(f"INSERTED as new (source=sheet): {len(inserted)}")
+    for n in inserted:
+        print(f"   + {n}")
+    print(f"\nMATCHED existing web signup & filled in blanks: {len(enriched)}")
+    for web, sheet, fields in enriched:
+        print(f"   ~ web '{web}'  <-  sheet '{sheet}'  (filled: {', '.join(fields)})")
+    print(f"\nMATCHED existing web signup, nothing to add: {len(matched_clean)}")
+    for web, sheet in matched_clean:
+        print(f"   = web '{web}'  ==  sheet '{sheet}'")
+    total = conn.execute("SELECT COUNT(*) FROM volunteers").fetchone()[0]
+    print(f"\nTotal rows in DB now: {total}")
+
+
+if __name__ == "__main__":
+    if "--go" not in sys.argv:
+        print("Dry run not implemented separately; pass --go to write. (DB is backed up.)")
+        sys.exit(1)
+    main()

--- a/volunteer/requirements.txt
+++ b/volunteer/requirements.txt
@@ -1,0 +1,8 @@
+blinker==1.9.0
+click==8.4.1
+Flask==3.1.3
+itsdangerous==2.2.0
+Jinja2==3.1.6
+MarkupSafe==3.0.3
+uWSGI==2.0.31
+Werkzeug==3.1.8

--- a/volunteer/rex-manor-volunteer.service
+++ b/volunteer/rex-manor-volunteer.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=uWSGI instance to serve the Rex Manor block party volunteer signup app
+After=network.target
+
+[Service]
+User=david
+Group=www-data
+WorkingDirectory=/home/david/webserver/rex-manor/volunteer
+Environment="PATH=/home/david/webserver/rex-manor/volunteer/venv/bin:/usr/local/bin:/usr/bin:/bin"
+ExecStart=/home/david/webserver/rex-manor/volunteer/venv/bin/uwsgi --ini volunteer.ini
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/volunteer/volunteer.ini
+++ b/volunteer/volunteer.ini
@@ -1,0 +1,8 @@
+[uwsgi]
+module = app:app
+master = true
+processes = 3
+socket = /home/david/webserver/rex-manor/volunteer/volunteer.sock
+chmod-socket = 660
+vacuum = true
+die-on-term = true


### PR DESCRIPTION
Brings the block party volunteer signup service **in-repo** under `volunteer/`, as a sibling of `webhook/` — matching how the other sites (personal-site, mvyimby) keep their Flask code and Hugo site together in one repo. It previously lived in an untracked `~/webserver/block-party-volunteer/` directory.

## Tracked
`app.py`, `import_sheet.py`, `db_to_sheet.py`, `export.py`, `volunteer.ini`, `rex-manor-volunteer.service`, `requirements.txt`, `README.md`.

## Gitignored (this repo is public)
`volunteer/venv/`, `volunteer/sheets-venv/`, `volunteer/data/` (SQLite DB + backups — **real signups, PII**), `volunteer/sheet_snapshot.md` (roster — **PII**), `__pycache__/`, `*.sock`.

## Server changes (already applied + verified live)
- systemd unit renamed `block-party-volunteer.service` → `rex-manor-volunteer.service`.
- uWSGI socket + nginx `uwsgi_pass` repointed to `volunteer/volunteer.sock`.
- venvs rebuilt at the new path; DB (42 merged rows) moved intact; form re-tested end-to-end through https://rexmanor.org/volunteer/.

🤖 Generated with [Claude Code](https://claude.com/claude-code)