### PR TITLE
Add June 2026 Events News Post

### DIFF
--- a/content/news/2026-06-events.md
+++ b/content/news/2026-06-events.md
@@ -1,0 +1,19 @@
+---
+title: "June Happenings: Community, Tech, and Local Music"
+date: 2026-06-13
+summary: "A look at upcoming June events, including STARTUPS MIX & PITCH at Hacker Dojo and summer concerts downtown."
+---
+
+Hello neighbors,
+
+First off, I want to say another huge thank you to everyone who made our annual Neighborhood Block Party such a great success. It was a fantastic afternoon of food, music, and conversation, and a wonderful reminder of the strong community we have here in Rex Manor.
+
+As we move deeper into June, our vibrant city of Mountain View has plenty of exciting events on the horizon. Our city is constantly evolving and growing, bringing new opportunities for connection and enjoyment.
+
+If you are looking for some outdoor entertainment, the **Concerts on the Plaza** series is back! You can catch live music every Friday from 6:00 p.m. to 7:30 p.m. at the Civic Center Plaza. It is a great way to kick off the weekend with neighbors and friends. Additionally, the **Music on Castro** series continues to bring wonderful live performances to Downtown Mountain View every Wednesday.
+
+On the technology front, we are lucky to have the Hacker Dojo so close by, fostering innovation and learning in our community. On Friday, June 26 at 6:00 PM, they are hosting **STARTUPS MIX & PITCH**. Whether you are a founder looking to share your ideas or just someone curious about the latest tech developments in our backyard, it is a great opportunity to connect with the local tech scene. The tech industry continues to be a positive driving force for our area, and these events are a great way to stay engaged.
+
+I hope you find time to enjoy some of these local offerings.
+
+— David Watson


### PR DESCRIPTION
This commit adds a new blog post for June 2026 events in Mountain View, focusing on community updates, tech events, and local music. It includes verified events such as Concerts on the Plaza, Music on Castro, and STARTUPS MIX & PITCH at Hacker Dojo, while acknowledging the successful annual Block Party from the local Google Group. The post is signed by David Watson and adheres to the pro-tech and anti-NIMBY styling guidelines.

---
*PR created automatically by Jules for task [10123759209300832937](https://jules.google.com/task/10123759209300832937) started by @davidfwatson*